### PR TITLE
Update PacketAnalyze.java

### DIFF
--- a/src/controll/PacketAnalyze.java
+++ b/src/controll/PacketAnalyze.java
@@ -93,11 +93,11 @@ public class PacketAnalyze {
             put("硬件类型", String.valueOf(arpPacket.hardtype));
             put("协议类型", "ARP");
             put("操作字段", String.valueOf(arpPacket.operation));
-            put("IP首部", arpPacket.toString());// String toString: 返回描述此数据包的字符串;
-            put("发送方硬件地址", (String) arpPacket.getSenderHardwareAddress());
-            put("接收方硬件地址", (String) arpPacket.getTargetHardwareAddress());
-            put("源IP", (String) arpPacket.getSenderProtocolAddress());
-            put("目的IP", (String) arpPacket.getTargetProtocolAddress());
+            // put("IP首部", arpPacket.toString());// String toString: 返回描述此数据包的字符串;
+            put("发送方硬件地址", String.valueOf(arpPacket.getSenderHardwareAddress()));
+            put("接收方硬件地址", String.valueOf(arpPacket.getTargetHardwareAddress()));
+            put("源IP",  String.valueOf(arpPacket.getSenderProtocolAddress()));
+            put("目的IP", String.valueOf(arpPacket.getTargetProtocolAddress()));
         }};
     }
 


### PR DESCRIPTION
解决编译时的报错，Exception in thread "Thread-2" java.lang.ClassCastException: class java.net.Inet4Address cannot be cast to class java.lang.String (java.net.Inet4Address and java.lang.String are in module java.base of loader 'bootstrap')
        at src.controll.PacketAnalyze$1.<init>(PacketAnalyze.java:102)
        at src.controll.PacketAnalyze.analyzeARPPacket(PacketAnalyze.java:93)
        at src.controll.PacketAnalyze.analyze(PacketAnalyze.java:77)
        at src.controll.PacketCapture.check(PacketCapture.java:130)
        at src.controll.PacketCapture.run(PacketCapture.java:98)
        at java.base/java.lang.Thread.run(Thread.java:833)